### PR TITLE
🩹 Revert "Bump h11 from 0.14.0 to 0.16.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -379,9 +379,9 @@ fqdn==1.5.1 \
     --hash=sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f \
     --hash=sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014
     # via jsonschema
-h11==0.16.0 \
-    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
-    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+h11==0.14.0 \
+    --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
+    --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
     # via httpcore
 httpcore==1.0.8 \
     --hash=sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be \


### PR DESCRIPTION
This reverts commit 970ebb7103bc3985ada3e3f5892cfbac6f4806b9.
Which was a result of merging https://github.com/glotaran/pub-2025-01-van_Stokkum_et_al/pull/2 and broke the CI.

The error itself was caused by a dependency conflict:
```
  Installing pip packages: -r requirements.txt
  ERROR: Cannot install -r /home/runner/work/pub-2025-01-van_Stokkum_et_al/pub-2025-01-van_Stokkum_et_al/requirements.txt (line 386) and h11==0.16.0 because these package versions have conflicting dependencies.
```

